### PR TITLE
user story #11 - enable and disable button from merchant item index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,13 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.5.6)
     nio4r (2.5.8)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     orderly (0.1.1)
@@ -216,6 +220,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,7 +17,11 @@ class ItemsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:merchant_id])
     @item = Item.find(params[:id])
-    if @item.update(item_params)
+
+    if params[:status].present?
+      @item.update(status: params[:status])
+      redirect_to merchant_items_path(@merchant)
+    elsif @item.update(item_params)
       redirect_to merchant_item_path(@merchant, @item)
       flash[:notice] = "Item successfully updated."
     else 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   validates :description, presence: true
   validates :unit_price, presence: true
   validates :merchant_id, presence: true
+  validates :status, presence: true
 
 
   def self.ready_to_ship(merchant_id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,6 +4,12 @@
 
 <ul>
   <% @items.each do |item| %>
-    <li><%= item.name %></li>
+    <div id=<%= "#{item.id}" %>>
+      <% if item.status == "disabled" %>
+        <li><%= item.name %></li><p><%= button_to "enable", merchant_item_path(@merchant.id, item.id), method: :patch, params: {status: "enabled"} %> </p>
+      <% else %>
+        <li><%= item.name %></li><p><%= button_to "disable", merchant_item_path(@merchant.id, item.id), method: :patch, params: {status: "disabled"} %> </p>
+      <% end %>
+    </div>
   <% end %>
 </ul>

--- a/db/migrate/20220917163257_add_status_to_items.rb
+++ b/db/migrate/20220917163257_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :string, default: "disabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 6) do
+ActiveRecord::Schema.define(version: 2022_09_17_163257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "disabled"
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe 'Merchant Items Index Page' do
         expect(page).to_not have_content("Item Provident At")
         expect(page).to_not have_content("Item Itaque Consequatur")
       end
+
+      it 'next to each item I see a button to disable or enable that item' do
+        item = Item.find_by(name: "Item Qui Esse")
+
+        expect(item.status).to eq("disabled")
+
+        visit merchant_items_path(Merchant.first)
+        
+        expect(page).to have_content("Item Qui Esse")
+        find("div#1").click_button("enable")
+
+        expect(current_path).to eq(merchant_items_path(Merchant.first))
+        expect(item.reload.status).to eq("enabled")
+        expect(page).to have_button("disable")
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:unit_price) }
+    it { should validate_presence_of(:status) }
     it { should validate_presence_of(:merchant_id) }
   end
 


### PR DESCRIPTION
*User Story 11*
- build out test for enable/disable button on merchant item index 
- build out logic in item controller for updating status
- migrate new "status" column in the items table 
- update item index view with appropriate buttons