### PR TITLE
Feat/top 5 merchant by revenue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     minitest (5.16.3)
     msgpack (1.5.6)
     nio4r (2.5.8)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     orderly (0.1.1)
@@ -216,6 +218,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,6 +2,7 @@ class Admin::MerchantsController < ApplicationController
   def index
     @enabled_merchants = Merchant.enabled_merchants
     @disabled_merchants = Merchant.disabled_merchants
+    @top_five_merchants = Merchant.top_five_by_revenue
   end
 
   def show

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -20,6 +20,11 @@ class Customer < ApplicationRecord
   end
 
   def self.top_five_customers_admin
-    joins(:transactions).where('transactions.result = 0').group(:last_name, :first_name).order(count: :desc).limit(5).count
+    joins(:transactions)
+      .where('transactions.result = 0')
+      .group(:last_name, :first_name)
+      .order(count: :desc)
+      .limit(5)
+      .count
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -22,4 +22,8 @@ class Merchant < ApplicationRecord
   def self.disabled_merchants
     all.where(status: "disabled")
   end
+
+  def top_five_by_revenue
+
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -16,14 +16,19 @@ class Merchant < ApplicationRecord
   end
 
   def self.enabled_merchants
-    all.where(status: "enabled")
+    where(status: "enabled")
   end
 
   def self.disabled_merchants
-    all.where(status: "disabled")
+    where(status: "disabled")
   end
 
-  def top_five_by_revenue
-
+  def self.top_five_by_revenue
+    joins(:items, invoices: :transactions)
+      .select('merchants.*, sum(invoice_items.unit_price * invoice_items.quantity) as revenue')
+      .group(:id)
+      .where(transactions: {result: 0})
+      .order(revenue: :desc)
+      .limit(5)
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,7 +10,7 @@
 <section id="top_five_merchants">
   <ol>
     <% @top_five_merchants.each do |merchant| %>
-      <li id="<%= merchant.id %>"><%= merchant.name %> - <%= merchant.revenue %></li>
+      <li id="<%= merchant.id %>"><%= link_to "#{merchant.name}", admin_merchant_path("#{merchant.id}")%> - <%= merchant.revenue %></li>
     <% end %>
   </ol>
 </section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -7,7 +7,13 @@
     <li><%= link_to "Invoices", admin_invoices_path %></li>
   </ul>
 </nav>
-
+<section id="top_five_merchants">
+  <ol>
+    <% @top_five_merchants.each do |merchant| %>
+      <li id="<%= merchant.id %>"><%= merchant.name %> - <%= merchant.revenue %></li>
+    <% end %>
+  </ol>
+</section>
 <section id="merchant_names">
   <div id="disabled_merchants">
     <h4> Disabled Merchants </h4>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,7 +10,7 @@
 <section id="top_five_merchants">
   <ol>
     <% @top_five_merchants.each do |merchant| %>
-      <li id="<%= merchant.id %>"><%= link_to "#{merchant.name}", admin_merchant_path("#{merchant.id}")%> - Revenue: <%= merchant.revenue %></li>
+      <li id="<%= merchant.id %>"><%= link_to "#{merchant.name}", admin_merchant_path("#{merchant.id}")%> - Revenue: $<%= '%.2f'% ((merchant.revenue.to_f) / 100) %></li>
     <% end %>
   </ol>
 </section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,7 +10,7 @@
 <section id="top_five_merchants">
   <ol>
     <% @top_five_merchants.each do |merchant| %>
-      <li id="<%= merchant.id %>"><%= link_to "#{merchant.name}", admin_merchant_path("#{merchant.id}")%> - <%= merchant.revenue %></li>
+      <li id="<%= merchant.id %>"><%= link_to "#{merchant.name}", admin_merchant_path("#{merchant.id}")%> - Revenue: <%= merchant.revenue %></li>
     <% end %>
   </ol>
 </section>

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe 'As an admin,' do
     it "I see a form filled in with the existing merchant attribute information" do
       visit admin_merchants_path
 
-      expect(page).to have_link("Schroeder-Jerde")
-      click_link "Schroeder-Jerde"
-      expect(page.current_path).to eq admin_merchant_path(1)
+      within("#disabled_merchants") do
+        expect(page).to have_link("Schroeder-Jerde")
+        click_link "Schroeder-Jerde"
+        expect(page.current_path).to eq admin_merchant_path(1)
+      end
 
       expect(page).to have_link("Update Merchant")
       click_link "Update Merchant"
@@ -23,9 +25,11 @@ RSpec.describe 'As an admin,' do
     it "When I update the information in the form and I click ‘submit’, Then I am redirected back to the merchant's admin show page where I see the updated information" do
       visit admin_merchants_path
 
-      expect(page).to have_link("Schroeder-Jerde")
-      click_link "Schroeder-Jerde"
-      expect(page.current_path).to eq admin_merchant_path(1)
+      within("#disabled_merchants") do
+        expect(page).to have_link("Schroeder-Jerde")
+        click_link "Schroeder-Jerde"
+        expect(page.current_path).to eq admin_merchant_path(1)
+      end
 
       expect(page).to have_link("Update Merchant")
       click_link "Update Merchant"
@@ -48,9 +52,11 @@ RSpec.describe 'As an admin,' do
     it "I see a flash message stating that the information has been successfully updated." do
       visit admin_merchants_path
 
-      expect(page).to have_link("Schroeder-Jerde")
-      click_link "Schroeder-Jerde"
-      expect(page.current_path).to eq admin_merchant_path(1)
+      within("#disabled_merchants") do
+        expect(page).to have_link("Schroeder-Jerde")
+        click_link "Schroeder-Jerde"
+        expect(page.current_path).to eq admin_merchant_path(1)
+      end
 
       expect(page).to have_link("Update Merchant")
       click_link "Update Merchant"
@@ -76,9 +82,11 @@ RSpec.describe 'As an admin,' do
     it "I see a flash message stating that the merchant failed to update if not given the correct information" do
       visit admin_merchants_path
 
-      expect(page).to have_link("Schroeder-Jerde")
-      click_link "Schroeder-Jerde"
-      expect(page.current_path).to eq admin_merchant_path(1)
+      within("#disabled_merchants") do
+        expect(page).to have_link("Schroeder-Jerde")
+        click_link "Schroeder-Jerde"
+        expect(page.current_path).to eq admin_merchant_path(1)
+      end
 
       expect(page).to have_link("Update Merchant")
       click_link "Update Merchant"

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -133,6 +133,8 @@ RSpec.describe 'As an admin,' do
     end
 
     it "I see that each merchant name links to the admin merchant show page for that merchant" do
+      visit admin_merchants_path
+
       within("#top_five_merchants") do
         expect(page).to have_link("Klein, Rempel and Jones")
         expect(page).to have_link("Schroeder-Jerde")
@@ -149,6 +151,8 @@ RSpec.describe 'As an admin,' do
     end
 
     it "I see the total revenue generated next to each merchant name" do
+      visit admin_merchants_path
+
       within("#top_five_merchants") do
         within("#2") do
           expect(page).to have_link("Klein, Rempel and Jones")

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe 'As an admin,' do
         expect(page).to have_content("Williamson Group")
         expect(page).to_not have_content("Bosco, Howe and Davis")
         expect(page).to_not have_content("Ullrich-Moen")
+      end
     end
 
     it "I see that each merchant name links to the admin merchant show page for that merchant" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -117,5 +117,63 @@ RSpec.describe 'As an admin,' do
         expect(page).to have_field("merchant_name")
       end
     end
+
+    it "I see the names of the top 5 merchants by total revenue generated" do
+      visit admin_merchants_path
+
+      within("#top_five_merchants") do
+        expect(page).to have_content("Klein, Rempel and Jones")
+        expect(page).to have_content("Schroeder-Jerde")
+        expect(page).to have_content("Willms and Sons")
+        expect(page).to have_content("Cummings-Thiel")
+        expect(page).to have_content("Williamson Group")
+        expect(page).to_not have_content("Bosco, Howe and Davis")
+        expect(page).to_not have_content("Ullrich-Moen")
+    end
+
+    it "I see that each merchant name links to the admin merchant show page for that merchant" do
+      within("#top_five_merchants") do
+        expect(page).to have_link("Klein, Rempel and Jones")
+        expect(page).to have_link("Schroeder-Jerde")
+        expect(page).to have_link("Willms and Sons")
+        expect(page).to have_link("Cummings-Thiel")
+        expect(page).to have_link("Williamson Group")
+        expect(page).to_not have_link("Bosco, Howe and Davis")
+        expect(page).to_not have_link("Ullrich-Moen")
+
+        click_on "Klein, Rempel and Jones"
+
+        expect(page.current_path).to eq admin_merchant_path(2)
+      end
+    end
+
+    it "I see the total revenue generated next to each merchant name" do
+      within("#top_five_merchants") do
+        within("#2") do
+          expect(page).to have_link("Klein, Rempel and Jones")
+          expect(page).to have_content("8538860")
+        end
+        within("#1") do
+          expect(page).to have_link("Schroeder-Jerde")
+          expect(page).to have_content("3345531")
+        end
+        within("#3") do
+          expect(page).to have_link("Willms and Sons")
+          expect(page).to have_content("1842708")
+        end
+        within("#4") do
+          expect(page).to have_link("Cummings-Thiel")
+          expect(page).to have_content("318518")
+        end
+        within("#6") do
+          expect(page).to have_link("Williamson Group")
+          expect(page).to have_content("253218")
+        end
+        expect(page).to_not have_link("Bosco, Howe and Davis")
+        expect(page).to_not have_content("49896565")
+        expect(page).to_not have_link("Ullrich-Moen")
+        expect(page).to_not have_content("3974755")
+      end
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -60,9 +60,11 @@ RSpec.describe 'As an admin,' do
         expect(find_all("li").count).to eq 29
       end
 
-      within("#1") do
-        expect(page).to have_button("disable")
-        expect(page).to_not have_button("enable")
+      within("#enabled_merchants") do
+        within("#1") do
+          expect(page).to have_button("disable")
+          expect(page).to_not have_button("enable")
+        end
       end
     end
 
@@ -78,22 +80,27 @@ RSpec.describe 'As an admin,' do
     it "I see that each Merchant is listed in the appropriate section" do
       visit admin_merchants_path
 
-      within("#1") do
-        expect(page).to have_button("enable")
-        click_on "enable"
-        expect(page.current_path).to eq admin_merchants_path
-      end
+      within("#disabled_merchants") do
+        within("#1") do
+          expect(page).to have_button("enable")
+          click_on "enable"
+          expect(page.current_path).to eq admin_merchants_path
+        end
 
-      within("#2") do
-        expect(page).to have_button("enable")
-        click_on "enable"
-        expect(page.current_path).to eq admin_merchants_path
-      end
+        visit admin_merchants_path
+        within("#2") do
+          expect(page).to have_button("enable")
+          click_on "enable"
+          expect(page.current_path).to eq admin_merchants_path
+          visit admin_merchants_path
+        end
 
-      within("#3") do
-        expect(page).to have_button("enable")
-        click_on "enable"
-        expect(page.current_path).to eq admin_merchants_path
+        visit admin_merchants_path
+        within("#3") do
+          expect(page).to have_button("enable")
+          click_on "enable"
+          expect(page.current_path).to eq admin_merchants_path
+        end
       end
 
       within("#enabled_merchants") do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -163,23 +163,23 @@ RSpec.describe 'As an admin,' do
       within("#top_five_merchants") do
         within("#2") do
           expect(page).to have_link("Klein, Rempel and Jones")
-          expect(page).to have_content("8538860")
+          expect(page).to have_content("$85388.60")
         end
         within("#1") do
           expect(page).to have_link("Schroeder-Jerde")
-          expect(page).to have_content("3345531")
+          expect(page).to have_content("$33455.31")
         end
         within("#3") do
           expect(page).to have_link("Willms and Sons")
-          expect(page).to have_content("1842708")
+          expect(page).to have_content("$18427.08")
         end
         within("#4") do
           expect(page).to have_link("Cummings-Thiel")
-          expect(page).to have_content("318518")
+          expect(page).to have_content("$3185.18")
         end
         within("#6") do
           expect(page).to have_link("Williamson Group")
-          expect(page).to have_content("253218")
+          expect(page).to have_content("$2532.18")
         end
         expect(page).to_not have_link("Bosco, Howe and Davis")
         expect(page).to_not have_content("49896565")

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -31,9 +31,11 @@ RSpec.describe 'As an admin,' do
     it "Then I see a link to update the merchant's information. When I click the link, then I am taken to a page to edit this merchant" do
       visit admin_merchants_path
 
-      expect(page).to have_link("Schroeder-Jerde")
-      click_link "Schroeder-Jerde"
-      expect(page.current_path).to eq admin_merchant_path(1)
+      within("#merchant_names") do
+        expect(page).to have_link("Schroeder-Jerde")
+        click_link "Schroeder-Jerde"
+        expect(page.current_path).to eq admin_merchant_path("1")
+      end
 
       expect(page).to have_link("Update Merchant")
       click_link "Update Merchant"

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -33,5 +33,19 @@ RSpec.describe Merchant, type: :model do
         expect(merchant.disabled_items.count).to eq(2)
       end
     end
+
+    describe "top_five_by_revenue" do
+      it "returns the top five merchants by revenue" do
+        klein = Merchant.find(2)
+        schroeder = Merchant.find(1)
+        willms = Merchant.find(3)
+        cummings = Merchant.find(4)
+        williamson = Merchant.find(6)
+
+        expected_arr = [klein, schroeder, willms, cummings, williamson]
+
+        expect(Merchant.top_five_by_revenue).to eq(expected_arr)
+      end
+    end
   end
 end


### PR DESCRIPTION
Solo
* Created tests for admin merchant top 5 by revenue
* Created logic for admin merchant top 5 by revenue
* Fixed failing tests due to ID association

I believe my AR query is doing what is required, however what is currently tripping me up is the story in bold.

Notes on Revenue Calculation:
- Only invoices with at least one successful transaction should count towards revenue
**- Revenue for an invoice should be calculated as the sum of the revenue of all invoice items**
- Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)